### PR TITLE
Splash jQuery disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"react-intl": "^3.3.2",
 		"react-moment": "^0.9.6",
 		"react-scripts": "3.2.0",
+		"react-scroll": "^1.7.14",
 		"react-typed": "^1.2.0",
 		"rss-parser": "^3.7.3",
 		"typescript": "3.6.3",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,8 +7,8 @@ import Preloader from './Preloader';
 import Slider from './Slider';
 import Header from './Header';
 import Home from './Home';
-
 import { MenuStateStore } from '../stores/MenuStateStore';
+
 import './App.css';
 
 const App = () => {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -49,6 +49,7 @@ class Header extends Component {
 					>
 						<FormattedMessage id="menu-resume" />
 					</li>
+
 					<li
 						className={portfolioState ? 'portfolio menu-item active' : 'portfolio menu-item'}
 						onClick={showPortfolioContent}

--- a/src/components/Home/PortfolioContent/Work/index.tsx
+++ b/src/components/Home/PortfolioContent/Work/index.tsx
@@ -49,7 +49,7 @@ const Work = ({ category, img, title, caption, fileName, showPopup }: workProps)
 
 	return (
 		<div className={'col-md-4 col-sm-6 col-xs-12 portfolio-item ' + category}>
-			<a className="open-project" href="#" onClick={() => showPopup(content)}>
+			<a className="open-project" onClick={() => showPopup(content)}>
 				<div className="portfolio-column">
 					<img src={wall} alt="" />
 					<div className="portfolio-content">

--- a/src/components/Home/ResumeContent/index.tsx
+++ b/src/components/Home/ResumeContent/index.tsx
@@ -22,7 +22,7 @@ class ResumeContent extends Component {
 
 		return (
 			<div className={style}>
-				<section className="content" id="resume">
+				<section className="content" id="resumeContent">
 					<Profile />
 					<Skills />
 					<Experience />

--- a/src/components/Preloader/index.tsx
+++ b/src/components/Preloader/index.tsx
@@ -1,22 +1,33 @@
 import React, { useEffect } from 'react';
+import { observer } from 'mobx-react';
 
 import Favicon from './favicon.png';
 
-import '../../jq';
+import * as Inject from '../../stores/MenuStateStore';
+
+import '../jq';
 import './styles.css';
 
+const useData = () => {
+	const { store }: Inject.Props = Inject.useStores();
+
+	return {
+		siteLoading: store.siteLoading,
+		removeSplash: store.removeSplash,
+		loadingComplete: store.loadingComplete,
+	};
+};
+
 const Preloader = () => {
+	const data = useData();
+	const style = data.siteLoading ? 'preloader' : 'preloader fadeOut';
+
 	useEffect(() => {
-		$(window).on('load', () => {
-			$('.preloader').fadeOut('slow', () => {
-				$('.preloader-left').addClass('slideOut-left');
-				$('.preloader-right').addClass('slideOut-right');
-			});
-		});
+		setTimeout(() => data.loadingComplete(), 500);
 	});
 
 	return (
-		<div className="preloader">
+		<div className={style} style={data.removeSplash ? { display: 'none' } : {}}>
 			<div className="anim pulse">
 				<img src={Favicon} alt="" />
 			</div>
@@ -24,4 +35,4 @@ const Preloader = () => {
 	);
 };
 
-export default Preloader;
+export default observer(Preloader);

--- a/src/components/Preloader/styles.sass
+++ b/src/components/Preloader/styles.sass
@@ -18,6 +18,10 @@
         left: 50%
         transform: translate(-50%, -50%)
 
+.fadeOut
+    opacity: 0
+    transition: opacity 0.5s ease
+
 .pulse
     -webkit-animation-duration: 1s
     animation-duration: 1s

--- a/src/components/Slider/index.tsx
+++ b/src/components/Slider/index.tsx
@@ -1,8 +1,30 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { observer } from 'mobx-react';
+
+import * as Inject from '../../stores/MenuStateStore';
+
 import './styles.css';
 
-const Slider = () => {
-	return <div className="preloader-left"></div>;
+const useData = () => {
+	const { store }: Inject.Props = Inject.useStores();
+
+	return {
+		siteLoading: store.siteLoading,
+		onRemoveSplash: store.onRemoveSplash,
+	};
 };
 
-export default Slider;
+const Slider = () => {
+	const data = useData();
+	const style = data.siteLoading ? 'preloader-left' : 'preloader-left slideOut-left';
+
+	useEffect(() => {
+		setTimeout(() => {
+			if (!data.siteLoading) data.onRemoveSplash();
+		}, 1000);
+	});
+
+	return <div className={style}></div>;
+};
+
+export default observer(Slider);

--- a/src/components/jq.tsx
+++ b/src/components/jq.tsx
@@ -1,0 +1,6 @@
+import * as jquery from 'jquery';
+
+export default Object.assign(global, {
+	$: jquery,
+	jQuery: jquery,
+});

--- a/src/jq.tsx
+++ b/src/jq.tsx
@@ -1,6 +1,0 @@
-import * as jquery from 'jquery';
-
-export default Object.assign(global, {
-	$: jquery,
-	jQuery: jquery,
-});

--- a/src/stores/MenuStateStore.tsx
+++ b/src/stores/MenuStateStore.tsx
@@ -1,6 +1,10 @@
+import React from 'react';
 import { observable, action } from 'mobx';
+import { MobXProviderContext } from 'mobx-react';
 
 export class MenuStateStore {
+	@observable siteLoading = true;
+	@observable removeSplash = false;
 	@observable menuItemState = false;
 	@observable blogState = false;
 	@observable contactState = false;
@@ -9,6 +13,14 @@ export class MenuStateStore {
 	@observable nameCardReverse = false;
 	@observable popupState = false;
 	@observable popupContent = null;
+
+	@action loadingComplete = () => {
+		this.siteLoading = false;
+	};
+
+	@action onRemoveSplash = () => {
+		this.removeSplash = true;
+	};
 
 	@action showBlogContent = () => {
 		this.blogState = true;
@@ -84,3 +96,7 @@ export interface ParentProps {}
 export interface Props extends ParentProps {
 	store: MenuStateStore;
 }
+
+export const useStores = () => {
+	return React.useContext(MobXProviderContext);
+};


### PR DESCRIPTION
Splash Screen에서 DOM 최적화 작업을 위해 jQuery를 사용한 스타일시트를 걷어냄.
React Hook이 보편화 됨에 따라 Splash Screen 코드에서 레거시 코드를 제거하고, 함수형으로 리팩토링.