### PR TITLE
Resolving communication error between API server

### DIFF
--- a/src/components/Home/BlogContent/index.tsx
+++ b/src/components/Home/BlogContent/index.tsx
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
 import { inject, observer } from 'mobx-react';
-import Parser, { Item } from 'rss-parser';
+import { Item } from 'rss-parser';
 
 import Post from './Post';
+import { receivePost } from '../../Server/nkapi/receivePost';
 
 import * as Inject from '../../../stores/MenuStateStore';
 
@@ -24,16 +25,7 @@ class BlogContent extends Component<BCProps, BCState> {
 			data: [],
 		};
 
-		const parser = new Parser({
-			defaultRSS: 4,
-			timeout: 1500,
-		});
-
-		const CORSFree = 'https://cors-anywhere.herokuapp.com/';
-
-		parser.parseURL(CORSFree + 'https://blog.neonkid.xyz/rss').then(feed => {
-			this.setState({ data: feed.items });
-		});
+		receivePost().then(feed => this.setState({ data: feed.items }));
 	}
 
 	prettyContent = (content: any) => {

--- a/src/components/Server/nkapi/contactMe.ts
+++ b/src/components/Server/nkapi/contactMe.ts
@@ -1,22 +1,15 @@
 import axios, { AxiosResponse, AxiosError } from 'axios';
+
 import endpoint from './endpoint.config';
 
 export const sendMsg = (name: string, email: string, msg: string): Promise<AxiosResponse & AxiosError> => {
 	return new Promise((resolve, reject) => {
 		axios
-			.post(
-				endpoint.contact.send.message,
-				{
-					name: name,
-					email: email,
-					message: msg,
-				},
-				{
-					headers: {
-						'Access-Control-Allow-Origin': '*',
-					},
-				},
-			)
+			.post(endpoint.contact.send.message, {
+				name: name,
+				email: email,
+				message: msg,
+			})
 			.then((resp: AxiosResponse) => resolve(resp.data))
 			.catch((err: AxiosError) => reject(err));
 	});

--- a/src/components/Server/nkapi/endpoint.config.ts
+++ b/src/components/Server/nkapi/endpoint.config.ts
@@ -2,6 +2,7 @@ const CORS_PROXY = 'https://cors-anywhere.herokuapp.com';
 
 const BLOG_URL = 'https://blog.neonkid.xyz/rss';
 const SERVER = 'https://apis.neonkid.xyz';
+const API_PREFIX = 'api';
 
 interface Config {
 	blog: {
@@ -26,7 +27,7 @@ const config: Config = {
 
 	contact: {
 		send: {
-			message: `${SERVER}/v1/sendMessage`,
+			message: `${SERVER}/${API_PREFIX}/v1/sendMessage`,
 		},
 	},
 };

--- a/src/components/Server/nkapi/endpoint.config.ts
+++ b/src/components/Server/nkapi/endpoint.config.ts
@@ -1,7 +1,15 @@
+const CORS_PROXY = 'https://cors-anywhere.herokuapp.com';
+
+const BLOG_URL = 'https://blog.neonkid.xyz/rss';
 const SERVER = 'https://apis.neonkid.xyz';
-const API_PREFIX = 'api';
 
 interface Config {
+	blog: {
+		receive: {
+			content: string;
+		};
+	};
+
 	contact: {
 		send: {
 			message: string;
@@ -10,9 +18,15 @@ interface Config {
 }
 
 const config: Config = {
+	blog: {
+		receive: {
+			content: `${CORS_PROXY}/${BLOG_URL}`,
+		},
+	},
+
 	contact: {
 		send: {
-			message: `${SERVER}/${API_PREFIX}/v1/sendMessage`,
+			message: `${SERVER}/v1/sendMessage`,
 		},
 	},
 };

--- a/src/components/Server/nkapi/receivePost.ts
+++ b/src/components/Server/nkapi/receivePost.ts
@@ -1,0 +1,17 @@
+import Parser, { Output } from 'rss-parser';
+
+import endpoint from './endpoint.config';
+
+export const receivePost = () => {
+	const parser = new Parser({
+		defaultRSS: 2.0,
+		timeout: 10000,
+	});
+
+	return new Promise<Output>((resolve, reject) => {
+		parser
+			.parseURL(endpoint.blog.receive.content)
+			.then((feed: Output) => resolve(feed))
+			.catch(err => reject(err));
+	});
+};


### PR DESCRIPTION
Fixed #67 

Resolve message transmission error due to setting error of API server
After refactoring the code for the blog RSS feed, change it to be set through ```CORS PROXY```.

(In case of RSS problem, we will discuss with the blog operator ```TISTORY``` how to solve it without going through ```CORS PROXY```.)